### PR TITLE
remove old Miri flags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,16 +26,10 @@ jobs:
       run: rustup toolchain install nightly --component miri --profile minimal
     - name: Miri Test
       run: cargo +nightly miri test
-      env:
-        MIRIFLAGS: -Zmiri-tag-raw-pointers
     - name: Test --no-default-features
       run: cargo +nightly miri test --no-default-features
-      env:
-        MIRIFLAGS: -Zmiri-tag-raw-pointers
     - name: Test --all-features
       run: cargo +nightly miri test --all-features
-      env:
-        MIRIFLAGS: -Zmiri-tag-raw-pointers
 
   thread_sanitizer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`-Zmiri-tag-raw-pointers` no longer has any effect on current versions of Miri; it is enabled by default.